### PR TITLE
Add role path

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ module "lambda_role" {
   custom_policies       = []
   custom_policies_count = 0
 
+  path = "/a/iam/path"
+
   # Attach policy for dead_letter_config.
   dead_letter_config = {
     target_arn = aws_sqs_queue.dlq.arn

--- a/role.tf
+++ b/role.tf
@@ -16,6 +16,7 @@ resource "aws_iam_role" "lambda" {
   count = var.enabled ? 1 : 0
 
   name               = var.function_name
+  path               = var.path
   assume_role_policy = data.aws_iam_policy_document.assume_role[0].json
   tags               = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,12 @@ variable "function_name" {
   type = string
 }
 
+variable "path" {
+  description = "The path to create the role at"
+  type        = string
+  default     = null
+}
+
 variable "policy_arns" {
   type    = list(string)
   default = []


### PR DESCRIPTION
Adds the role path parameter to enable the creation or import of roles at IAM paths other than the root.